### PR TITLE
Fix error when running Atom from Windows GUI

### DIFF
--- a/lib/shell-it.coffee
+++ b/lib/shell-it.coffee
@@ -88,7 +88,7 @@ module.exports =
     
   process: (cwd, cmd, stdin, selout, clipout) ->
     try
-      stdout = exec cmd, {cwd, input: stdin, timeout: 5e3}
+      stdout = exec cmd, {cwd, input: stdin, timeout: 5e3, stdio: 'pipe'}
       stdout = stdout.toString()
     catch e
       atom.confirm


### PR DESCRIPTION
When not running Atom from command line in Windows, stdin and stdout do not work as expected.

The addition of `, stdio: 'pipe'` fixes it.
If it doesn't mess up anything for Linux and OSX, it might be worth merging.
